### PR TITLE
Adding @_file_upload tag to Behat tests requiring it.

### DIFF
--- a/tests/behat/import_test.feature
+++ b/tests/behat/import_test.feature
@@ -1,4 +1,4 @@
-@ou @ou_vle @qtype @qtype_pmatch
+@ou @ou_vle @qtype @qtype_pmatch @_file_upload
 Feature: Import and export pattern match questions
   As a teacher
   In order to reuse my pattern match questions

--- a/tests/behat/testquestion_upload_responses.feature
+++ b/tests/behat/testquestion_upload_responses.feature
@@ -1,4 +1,4 @@
-@ou @ou_vle @qtype @qtype_pmatch
+@ou @ou_vle @qtype @qtype_pmatch @_file_upload
 Feature: Test uploading test responses in the pattern match test this question feature
   In order to test pattern match question accuracy
   As a teacher


### PR DESCRIPTION
This prevents CiBoT fails with the message
`
Behat\Mink\Exception\DriverException: File upload tests must have the @_file_upload tag on either the scenario or feature.
`
from happening.

Thanks.