### PR TITLE
Replace grade by gradenoun string.

### DIFF
--- a/edit_pmatch_form.php
+++ b/edit_pmatch_form.php
@@ -206,7 +206,7 @@ class qtype_pmatch_edit_form extends question_edit_form {
         $otheranswerhdr = $mform->addElement('static', 'otheranswerhdr',
                                                 get_string('anyotheranswer', 'qtype_pmatch'));
         $otheranswerhdr->setAttributes(array('class' => 'otheranswerhdr'));
-        $mform->addElement('static', 'otherfraction', get_string('grade'), '0%');
+        $mform->addElement('static', 'otherfraction', get_string('gradenoun'), '0%');
         $mform->addElement('editor', 'otherfeedback', get_string('feedback', 'question'),
                                                         array('rows' => 5), $this->editoroptions);
     }
@@ -295,7 +295,7 @@ class qtype_pmatch_edit_form extends question_edit_form {
             }
         }
         $repeated[] = $mform->createElement('select', 'fraction',
-                                                                get_string('grade'), $gradeoptions);
+                                                                get_string('gradenoun'), $gradeoptions);
         $repeated[] = $mform->createElement('editor', 'feedback',
                                 get_string('feedback', 'question'),
                                 array('rows' => 5), $this->editoroptions);


### PR DESCRIPTION
Despite [this comment](https://github.com/moodleou/moodle-qtype_pmatch/pull/60#issuecomment-1201387900) I don't see gradenoun used in the edit_pmatch_form.php file.