### PR TITLE
68 Fix Fatal error declaration of assert_same_xml

### DIFF
--- a/tests/testquestion_test_base.php
+++ b/tests/testquestion_test_base.php
@@ -232,8 +232,14 @@ class testquestion_test_base extends \question_testcase {
      * @param string $expectedxml Expected xml content
      * @param string $xml Actual xml content
      */
-    public function assert_same_xml(string $expectedxml, string $xml) {
-        $this->assertEquals(str_replace("\r\n", "\n", $expectedxml),
-                str_replace("\r\n", "\n", $xml));
+    public function assert_same_xml($expectedxml, $xml) {
+        // Use our own implementation if method not present in parent class.
+        // (Method was added to parent class in Moodle 4.4.1 by MDL-81581).
+        if (!method_exists(parent::class, 'assert_same_xml')) {
+            $this->assertEquals(str_replace("\r\n", "\n", $expectedxml),
+                    str_replace("\r\n", "\n", $xml));
+        } else {
+            parent::assert_same_xml($expectedxml, $xml);
+        }
     }
 }


### PR DESCRIPTION
MDL-81581 moved assert_same_xml() into \question_testcase so any implementation a subclass must match this definition.

While removing type declarations for assert_same_xml()'s parameters would fix this, this PR additionally uses the parent's implementation if present, falling back to the existing implementation if if it isn't to avoid making the plugin dependent on Moodle versions >= 4.4.1. This is a little clunky but makes explicit that the core code change means the existing implementation is considered deprecated.

(In core, MDL-81581 removed qtype plugins' implementations of assert_same_xml(), but we can't do that without making qtype_pmatch dependent on Moodle >= 4.4.1).