### PR TITLE
Fix pmatch spell-check OOM on long punctuated input

### DIFF
--- a/pmatchlib.php
+++ b/pmatchlib.php
@@ -468,11 +468,29 @@ class pmatch_parsed_string {
             return null;
         }
 
-        // Try trimming one non-letter character from the end or start, if present.
-        if (preg_match('~[^\pL]$~u', $word)) {
-            return $this->is_word_misspelled(core_text::substr($word, 0, -1));
-        } else if (preg_match('~^[^\pL]~u', $word)) {
-            return $this->is_word_misspelled(core_text::substr($word, 1));
+        // Try trimming non-letter characters from the end or start, if present.
+        // This was previously recursive, but long punctuated inputs could create a deep
+        // call stack and many transient string copies. Iterative trimming keeps the same
+        // matching behaviour while bounding stack growth and reducing peak memory pressure.
+        // Keep checking dictionary membership after each trim, so wrapped valid words still
+        // short-circuit as soon as a dictionary form is reached. Trailing characters are
+        // stripped before leading ones, matching the original recursive order.
+        while (preg_match('~[^\pL]$~u', $word) || preg_match('~^[^\pL]~u', $word)) {
+            $word = preg_match('~[^\pL]$~u', $word)
+                ? core_text::substr($word, 0, -1)
+                : core_text::substr($word, 1);
+            if (trim($word) === '') {
+                return null;
+            }
+            foreach ($this->options->words_to_ignore_patterns() as $wordstoignorepattern) {
+                if (preg_match('~'.$wordstoignorepattern.$endofpattern, $word)) {
+                    // Is a number, extra dictionary word or synonym.
+                    return null;
+                }
+            }
+            if ($spellchecker->is_in_dictionary($word)) {
+                return null;
+            }
         }
 
         // Finally, if what is left after all punctuation is removed contains hyphens,

--- a/tests/parsed_string_test.php
+++ b/tests/parsed_string_test.php
@@ -194,6 +194,29 @@ final class parsed_string_test extends \basic_testcase {
     }
 
     /**
+     * Regression test for long punctuated responses.
+     *
+     * The assertion focus is that spell-checking completes and produces a result array.
+     */
+    public function test_pmatch_spelling_with_long_punctuated_sentence(): void {
+        $options = new pmatch_options();
+        $options->lang = 'en_GB';
+
+        \qtype_pmatch_test_helper::skip_test_if_no_spellcheck($this, $options->lang);
+
+        $string = 'During routine checks, the operations team reviewed multiple records, noted repeated '
+                . 'format anomalies, and applied consistent corrections to preserve readability, accuracy, '
+                . 'and traceability across archived responses, while ensuring punctuation-heavy input '
+                . 'continued to process without excessive resource usage.';
+
+        $parsedstring = new pmatch_parsed_string($string, $options);
+
+        $this->assertGreaterThan(0, $parsedstring->get_word_count());
+        $parsedstring->is_spelled_correctly();
+        $this->assertIsArray($parsedstring->get_spelling_errors());
+    }
+
+    /**
      * Test get_display_name_for_language_code
      *
      * @dataProvider get_display_name_for_language_code_provider


### PR DESCRIPTION
closes #83 

- Summary: replaces recursive punctuation stripping in pmatch spell checking with iterative trimming to avoid excessive memory use and stack growth on long punctuated tokens.

- Root cause: is_word_misspelled() recursively called itself while stripping one non-letter character at a time, creating many intermediate large strings on pathological input.

- Fix: iterative loops now trim from end/start and re-check dictionary membership without recursion.

- Tests: adds regression test for long punctuated sentence parsing/spell-check path in parsed_string_test.

- Scope: no behavior changes outside punctuation-trimming path; debug logging changes are excluded.